### PR TITLE
Guard console logs and document key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ const auth = getAuth(app);
 export { database, ref, onValue, push, get, update, remove, auth, signInWithEmailAndPassword };
 ```
 
+### 🔐 Key Management / Avainten hallinta
+
+Store Firebase API keys and other secrets in environment variables instead of hardcoding them into the source. Create a `.env` file in the project root:
+
+```env
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_domain
+VITE_FIREBASE_DATABASE_URL=your_database_url
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+```
+
+Do not commit the `.env` file to version control (it's already ignored). Configure Firebase Realtime Database rules to restrict access and protect data.
+
 ---
 
 ### 🔹 Run the app / Käynnistä sovellus

--- a/README.txt
+++ b/README.txt
@@ -95,6 +95,22 @@ const auth = getAuth(app);
 export { database, ref, onValue, push, get, update, remove, auth, signInWithEmailAndPassword };
 ```
 
+### 🔐 Key Management / Avainten hallinta
+
+Store Firebase API keys and other secrets in environment variables instead of hardcoding them into the source. Create a `.env` file in the project root:
+
+```env
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_domain
+VITE_FIREBASE_DATABASE_URL=your_database_url
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+```
+
+Do not commit the `.env` file to version control (it's already ignored). Configure Firebase Realtime Database rules to restrict access and protect data.
+
 ---
 
 ### 🔹 Run the app / Käynnistä sovellus

--- a/backend/server.js
+++ b/backend/server.js
@@ -325,5 +325,7 @@ const PORT = 5000;
 const HOST = '0.0.0.0'; // 🔥 Tämä sallii yhteydet kaikilta IP-osoitteilta (mukaan lukien Tailscale)
 
 app.listen(5000, '0.0.0.0', () => {
-    console.log('Server running on port 5000');
+    if (process.env.NODE_ENV !== 'production') {
+        console.log('Server running on port 5000');
+    }
 });

--- a/frontend/src/EditTrip.jsx
+++ b/frontend/src/EditTrip.jsx
@@ -30,7 +30,7 @@ function EditTrip({ onRequestClose, tripId }) {
       if (data) {
         setInventory(data);
         setIsInventoryLoaded(true);
-        console.log("Inventory loaded:", data);
+          if (import.meta.env.DEV) console.log("Inventory loaded:", data);
       }
     });
   }, []);
@@ -38,14 +38,14 @@ function EditTrip({ onRequestClose, tripId }) {
   useEffect(() => {
     if (!isInventoryLoaded || !id) return;
 
-    console.log(`Fetching trip with ID: ${id}`); // Log the ID being used
+      if (import.meta.env.DEV) console.log(`Fetching trip with ID: ${id}`); // Log the ID being used
 
     const tripRef = ref(database, `keikat/${id}`);
     get(tripRef)
       .then((snapshot) => {
         if (snapshot.exists()) {
           const data = snapshot.val();
-          console.log("Trip data retrieved:", data); // Log the data retrieved
+            if (import.meta.env.DEV) console.log("Trip data retrieved:", data); // Log the data retrieved
           setName(data.name || "");
           setContact(data.contact || "");
           setStartDate(data.startDate ? new Date(data.startDate) : null);

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -62,7 +62,7 @@ function Home() {
   }, [location.state, navigate]);
 
   const handleSelectTrip = (id) => {
-    console.log("Selected Trip ID:", id);
+    if (import.meta.env.DEV) console.log("Selected Trip ID:", id);
     setSelectedTripId(id);
     setIsEditTripModalOpen(true);
   };

--- a/frontend/src/ShelfAdmin.jsx
+++ b/frontend/src/ShelfAdmin.jsx
@@ -74,7 +74,7 @@ function ShelfAdmin() {
     };
     set(ref(database, shelfPath), data)
       .then(() => {
-        console.log(`Hylly ${nextKey} lisätty`);
+        if (import.meta.env.DEV) console.log(`Hylly ${nextKey} lisätty`);
         alert(`Hylly ${nextKey} lisätty valmiilla rakenteella!`);
       })
       .catch((error) => {

--- a/frontend/src/firebaseConfig.js
+++ b/frontend/src/firebaseConfig.js
@@ -3,11 +3,6 @@ import { getDatabase, ref, push, onValue, update, remove, set } from "firebase/d
 import { get, child } from "firebase/database";
 import { getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
 
-console.log("Firebase API Key:", import.meta.env.VITE_FIREBASE_API_KEY);
-console.log("Firebase Auth Domain:", import.meta.env.VITE_FIREBASE_AUTH_DOMAIN);
-console.log("Firebase Project ID:", import.meta.env.VITE_FIREBASE_PROJECT_ID);
-
-
 // 🔹 Sinun Firebase-konfiguraatiosi:
 const firebaseConfig = {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,


### PR DESCRIPTION
## Summary
- wrap console logging behind environment checks
- remove firebase config logging in favor of environment variables
- document env-based key management and Firebase rules

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)
- `cd backend && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_b_68a5b8baada4832a860977c57ec73212